### PR TITLE
Fix wrong buffer indexes

### DIFF
--- a/plugin/dokuvimki.vim
+++ b/plugin/dokuvimki.vim
@@ -114,7 +114,7 @@ except ImportError:
     print >>sys.stderr, 'DokuVimKi Error: The dokuwikixmlrpc python module is missing!'
     has_dokuwikixmlrpc = False
 
-
+vim_version = int(vim.eval('v:version'))
 
 class DokuVimKi:
     """
@@ -1034,7 +1034,13 @@ class Buffer:
         """
         vim.command('badd ' + name)
         self.num  = vim.eval('bufnr("' + name + '")')
-        self.id   = int(self.num) - 1
+
+        # buffers are numbered from 0 in vim 7.3 and older
+        # and from 1 in vim 7.4 and newer
+        self.id = int(self.num)
+        if vim_version < 704:
+            self.id -= 1
+
         self.buf  = vim.buffers[self.id]
         self.name = name
         self.iswp = iswp


### PR DESCRIPTION
Today I installed dokuvimki and I got error when executing vim +DokuVimKi

```
Refreshing page index!
Refreshing media index!
Traceback (most recent call last):
 File "<string>", line 1, in <module>
 File "<string>", line 983, in dokuvimki
 File "<string>", line 76, in __init__
 File "<string>", line 388, in index
vim.error: cannot save undo information
Error detected while processing :
E21: Cannot make changes, 'modifiable' is off
```

After your help and 2 hours of testing :) I found out that with my version vim.buffers have same numbers as returned from bufnr function.

Maybe there is some change in vim with new versions, I'm not sure. My vim version is 7.4.052

With this fix, everything is working on my computer.
