### PR TITLE
add the capability to use white space and unicode character  in page names

### DIFF
--- a/plugin/dokuvimki.vim
+++ b/plugin/dokuvimki.vim
@@ -852,9 +852,7 @@ class DokuVimKi:
         locks['unlock'] = [ wp ]
 
         result = self.set_locks(locks)
-        """
-        FIXME UnicodeWarning: Unicode equal comparison failed to convert both arguments to unicode
-        """
+
         if locks['unlock'] == [x.encode('utf-8') for x in result['unlocked']]:
             return True
         else:


### PR DESCRIPTION
When editing pagename including Unicode and whitespace, there's a bug caused by Unicode equal comparison failed. This commit fix the issue.
