### PR TITLE
External password manager

### DIFF
--- a/doc/dokuvimki.txt
+++ b/doc/dokuvimki.txt
@@ -73,6 +73,9 @@ g:DokuVimKi_USER             The username used to login into the remote wiki.
 
 g:DokuVimKi_PASS             The password used to login into the remote wiki.
 
+g:DokuVimKi_PASS_EVAL        Call an external program to get the password.
+                             E.g. GNU pass. 
+
 g:DokuVimKi_URL              The URL of the remote wiki (no trailing slash!).
 
 The following variables are optional and have a default:

--- a/plugin/dokuvimki.py
+++ b/plugin/dokuvimki.py
@@ -100,33 +100,26 @@ class DokuVimKi:
 
         try:
             dw_user = vim.eval('g:DokuVimKi_USER')
-
-            if vim.eval('exists(\'g:DokuVimKi_PASS\')') != "0":
-                dw_pass = vim.eval('g:DokuVimKi_PASS')
-
-            if vim.eval('exists(\'g:DokuVimKi_PASS_EVAL\')') != "0":
-                dw_pass_eval = vim.eval('g:DokuVimKi_PASS_EVAL')
-
+            dw_pass = vim.eval('get(g:, "DokuVimKi_PASS", "")')
+            dw_pass_eval = vim.eval('get(g:, "DokuVimKi_PASS_EVAL", "")')
             dw_url = vim.eval('g:DokuVimKi_URL')
             http_basic_auth = bool(vim.eval('g:DokuVimKi_HTTP_BASIC_AUTH'))
         except vim.error as err:
             print("Error: %s. Please check your configuration settings." % err, file=sys.stderr)
             return False
 
-        if 'dw_pass' not in locals() and 'dw_pass_eval' not in locals():
+        if not dw_pass and not dw_pass_eval:
             print("Error: Please either define the DokuVimKi_PASS or DokuVimKi_PASS_EVAL", file=sys.stderr)
             return False
 
         try:
-            if 'dw_pass_eval' in locals():
+            if dw_pass_eval:
                 passw = subprocess.run(dw_pass_eval.split(" "), stdout=subprocess.PIPE).stdout
-                passw = ''.join(chr(x) for x in passw)
-            else:
-                passw = dw_pass
+                dw_pass = ''.join(chr(x) for x in passw)
 
             if http_basic_auth:
                 print('Using HTTP basic authentication')
-            self.xmlrpc = dokuwikixmlrpc.DokuWikiClient(dw_url, dw_user, passw, http_basic_auth=http_basic_auth)
+            self.xmlrpc = dokuwikixmlrpc.DokuWikiClient(dw_url, dw_user, dw_pass, http_basic_auth=http_basic_auth)
             dw_version = self.xmlrpc.dokuwiki_version
             print('Connection to %s established (DokuWiki version: %s)' % (dw_url, dw_version), file=sys.stdout)
             return True

--- a/plugin/dokuvimki.py
+++ b/plugin/dokuvimki.py
@@ -114,12 +114,12 @@ class DokuVimKi:
             return False
 
         if 'dw_pass' not in locals() and 'dw_pass_eval' not in locals():
-#           print("Error: Please either define the DokuVimKi_PASS or DokuVimKi_PASS_EVAL", file=sys.stderr)
+            print("Error: Please either define the DokuVimKi_PASS or DokuVimKi_PASS_EVAL", file=sys.stderr)
             return False
 
         try:
             if 'dw_pass_eval' in locals():
-                passw = subprocess.run(dw_pass_eval.split(" "), stdout=subprocess.PIPE).stdout[-1]
+                passw = subprocess.run(dw_pass_eval.split(" "), stdout=subprocess.PIPE).stdout
                 passw = ''.join(chr(x) for x in passw)
             else:
                 passw = dw_pass


### PR DESCRIPTION
Hi Kynan.

I really love the plugin. It is very useful. I had only one issue with it. That the password had to be writing in the configuration. I have made a suggestion to solve this. It is done by calling an external program that handles the password. There exists a number of password manager which has commandline interface, such as GNU pass. 

So I have added an extra variable called DokuVimKI_PASS_EVAL, which would contain the command to run. so it could look like 
let DokuVimKi_PASS_EVAL = 'pass wiki'. 

Best,
TheWorldOfCode :-D 